### PR TITLE
fix: use personal access token for checkout when bumping version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT }}
       - name: Bump version and create changelog
         uses: commitizen-tools/commitizen-action@0.18.0
         with:


### PR DESCRIPTION
2nd attempt at getting the bump version commit push to trigger a workflow to release the package to pypi